### PR TITLE
fix: Next.js Image 컴포넌트 외부 도메인 설정 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,34 @@ const withPWA = require('next-pwa')({
 
 const nextConfig: NextConfig = {
   // Next.js 15에서는 appDir이 기본값이므로 제거
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'img1.kakaocdn.net',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'img1.kakaocdn.net',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'http',
+        hostname: 't1.kakaocdn.net',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 't1.kakaocdn.net',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
- 카카오 프로필 이미지 도메인 허용 (img1.kakaocdn.net, t1.kakaocdn.net)
- HTTP/HTTPS 프로토콜 모두 지원
- Next.js Image 컴포넌트 외부 이미지 로드 오류 해결