### PR TITLE
fix: Fix education card heart icon initial state

### DIFF
--- a/src/app/education-programs/page.tsx
+++ b/src/app/education-programs/page.tsx
@@ -13,6 +13,7 @@ import {
   getRecommendedEducations,
   getAllEducationsAnonymous,
   getHrdEducations,
+  getEducationBookmarks,
 } from '@/lib/api/jobApi';
 import { EducationSummary } from '@/types/job';
 
@@ -54,7 +55,23 @@ export default function EducationPrograms() {
     if (!loggedIn) {
       setActiveTab('all');
     }
+
+    // 로그인된 경우 찜 목록 로드
+    if (loggedIn) {
+      loadBookmarks();
+    }
   }, []);
+
+  // 찜 목록 로드 함수
+  const loadBookmarks = async () => {
+    try {
+      const bookmarkIds = await getEducationBookmarks();
+      setFavorites(new Set(bookmarkIds));
+      console.log('EducationPrograms - Loaded bookmarks:', bookmarkIds);
+    } catch (error) {
+      console.error('Error loading education bookmarks:', error);
+    }
+  };
 
   // 검색어 디바운싱 (500ms 지연)
   useEffect(() => {
@@ -258,6 +275,7 @@ export default function EducationPrograms() {
                           key={education.trprId || index}
                           education={education}
                           onToggleBookmark={toggleFavorite}
+                          isBookmarked={favorites.has(education.trprId || '')}
                         />
                       );
                     })}
@@ -278,6 +296,7 @@ export default function EducationPrograms() {
                           }
                           education={education}
                           onToggleBookmark={toggleFavorite}
+                          isBookmarked={favorites.has(education.trprId || '')}
                         />
                       );
                     })}

--- a/src/components/features/job/EducationCard.tsx
+++ b/src/components/features/job/EducationCard.tsx
@@ -187,15 +187,17 @@ const DetailItem = ({
 interface EducationCardProps {
   education: EducationSummary;
   onToggleBookmark: (educationId: string) => void;
+  isBookmarked?: boolean;
 }
 
 export default function EducationCard({
   education,
   onToggleBookmark,
+  isBookmarked = false,
 }: EducationCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
-  const [isBookmark, setIsBookmark] = useState(education.isBookmark || false);
+  const [isBookmark, setIsBookmark] = useState(isBookmarked);
   const [isHovered, setIsHovered] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
@@ -203,6 +205,11 @@ export default function EducationCard({
     const userData = getUserData();
     setIsLoggedIn(!!userData);
   }, []);
+
+  // isBookmarked prop이 변경될 때 isBookmark 상태 업데이트
+  useEffect(() => {
+    setIsBookmark(isBookmarked);
+  }, [isBookmarked]);
 
   const handleToggleBookmark = (educationId: string) => {
     setIsBookmark(!isBookmark);
@@ -355,10 +362,10 @@ export default function EducationCard({
                     handleToggleBookmark(education.trprId);
                   }}
                   className={`text-3xl md:text-5xl transition-all duration-300 hover:scale-110 ${
-                    isBookmark ? 'text-gray-300' : 'text-yellow-400'
+                    isBookmark ? 'text-yellow-400' : 'text-gray-300'
                   }`}
                 >
-                  {isBookmark ? <PiStarThin /> : <HiStar />}
+                  {isBookmark ? <HiStar /> : <PiStarThin />}
                 </button>
               </div>
             </div>

--- a/src/lib/api/jobApi.ts
+++ b/src/lib/api/jobApi.ts
@@ -1598,3 +1598,40 @@ export const getHrdEducations = async (filters?: {
     throw error;
   }
 };
+
+// 교육 프로그램 찜 목록 조회
+export const getEducationBookmarks = async (): Promise<string[]> => {
+  try {
+    const token = getAccessToken();
+    if (!token) {
+      throw new Error('Access token not found');
+    }
+
+    const response = await fetch('/api/heart-lists/edu/history', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch education bookmarks');
+    }
+
+    const result = await response.json();
+
+    if (result.result !== 'SUCCESS') {
+      throw new Error(result.error?.message || 'API request failed');
+    }
+
+    // API 응답에서 교육 프로그램 ID 목록 추출
+    return (
+      result.data?.map(
+        (item: { trprId?: string; id?: string }) => item.trprId || item.id
+      ) || []
+    );
+  } catch (error) {
+    console.error('Error fetching education bookmarks:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
- 처음에 empty heart를 표시하도록 EducationCard 구성 요소 수정
- 사용자의 북마크 교육을 로드하기 위해 getEducationBookmarks API 기능 추가
- 북마크 상태를 카드에 로드하고 전달할 수 있도록 교육 프로그램 페이지 업데이트
- 하트 아이콘 표시 로직 수정(북마크되지 않은 경우 빈 별, 북마크된 경우 채워진 별)
- 교육 프로그램 하트 아이콘의 올바른 초기 상태 확인
- 모든 유형의 TypeScript를 적절한 인터페이스로 수정